### PR TITLE
Add pre-commit hooks for automatic line wrapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: 24.3.0
     hooks:
     -   id: black
+        args: [--preview]  # More aggressive line breaking
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
@@ -43,3 +44,23 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py310-plus]
+
+-   repo: local
+    hooks:
+    -   id: docformatter
+        name: docformatter
+        description: 'Formats docstrings to follow PEP 257'
+        entry: docformatter
+        args: [--in-place, --wrap-summaries=88, --wrap-descriptions=88]
+        language: python
+        types: [python]
+
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v2.2.1
+    hooks:
+    -   id: autoflake
+        args: [
+            --remove-all-unused-imports,
+            --remove-unused-variables,
+            --in-place
+        ]


### PR DESCRIPTION
# Improve Pre-commit Hooks for Automatic Line Wrapping

This PR adds additional pre-commit hooks to automatically handle line wrapping and code cleanup, which will save time during development and code reviews.

## Changes

- Added Black's `--preview` option for more aggressive line breaking
- Added docformatter hook to automatically wrap docstrings
- Added autoflake hook to remove unused imports and variables

## Benefits

- Reduces manual effort needed to fix line length issues
- Ensures consistent docstring formatting
- Automatically cleans up unused imports and variables
- Makes code reviews more focused on functionality rather than formatting

## Testing

The hooks have been tested locally and work as expected.

## Note for Contributors

After merging this PR, contributors should run `pre-commit install` to update their local hooks.
